### PR TITLE
Bugfix

### DIFF
--- a/test.js
+++ b/test.js
@@ -35,7 +35,7 @@ process.stdin.on('keypress', (ch, key) => {
 	// Check if i pressed a key
 	let pickedChar = "";
 
-	if (key.name !== "enter") {
+	if (key && key.name !== "enter") {
 		pickedChar = key.name;
 		// TODO: check if it matched my selected square
 		// TODO: check board position X for match
@@ -44,7 +44,7 @@ process.stdin.on('keypress', (ch, key) => {
 	}
 
 	// Process rest
-	if (key.name === "enter") {
+	if (key && key.name === "enter") {
 		// Generate new letter
 		const generatedChar = bagOfChars[Math.floor(Math.random() * bagOfChars.length)];
 


### PR DESCRIPTION
The keypress event can fire with an undefined key object in some cases, causing a TypeError when trying to access key.name. Added checks to ensure key is defined before accessing its properties.

This fixes the error:
TypeError: Cannot read properties of undefined (reading 'name')

🤖 Generated with [Claude Code](https://claude.com/claude-code)