### PR TITLE
Add comprehensive test suite with Vitest

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,8 +16,71 @@
         "@types/bun": "^1.3.1",
         "@types/keypress": "^2.0.30",
         "@types/node": "^20.10.0",
+        "@vitest/coverage-v8": "^4.0.3",
+        "@vitest/ui": "^4.0.3",
         "bun-types": "^1.0.0",
-        "tsx": "^4.20.6"
+        "tsx": "^4.20.6",
+        "vitest": "^4.0.3"
+      }
+    },
+    "node_modules/@babel/helper-string-parser": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
+      "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.28.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
+      "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/parser": {
+      "version": "7.28.5",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.28.5.tgz",
+      "integrity": "sha512-KKBU1VGYR7ORr3At5HAtUQ+TV3SzRCXmA/8OdDZiLDBIZxVyzXuztPjfLd3BV1PRAQGCMWWSHYhL0F8d5uHBDQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.28.5"
+      },
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/types": {
+      "version": "7.28.5",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.28.5.tgz",
+      "integrity": "sha512-qQ5m48eI/MFLQ5PxQj4PFaprjyCTLI37ElWMmNs0K8Lk3dVeOdNpB3ks8jc7yM5CDmVC73eMVk/trk3fgmrUpA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.27.1",
+        "@babel/helper-validator-identifier": "^7.28.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@bcoe/v8-coverage": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-1.0.2.tgz",
+      "integrity": "sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -462,6 +525,356 @@
         "node": ">=18"
       }
     },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@polka/url": {
+      "version": "1.0.0-next.29",
+      "resolved": "https://registry.npmjs.org/@polka/url/-/url-1.0.0-next.29.tgz",
+      "integrity": "sha512-wwQAWhWSuHaag8c4q/KN/vCoeOJYshAIvMQwD4GpSb3OiZklFfvAgmj0VCBBImRpuF/aFgIRzllXlVX93Jevww==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.52.5",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.52.5.tgz",
+      "integrity": "sha512-8c1vW4ocv3UOMp9K+gToY5zL2XiiVw3k7f1ksf4yO1FlDFQ1C2u72iACFnSOceJFsWskc2WZNqeRhFRPzv+wtQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.52.5",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.52.5.tgz",
+      "integrity": "sha512-mQGfsIEFcu21mvqkEKKu2dYmtuSZOBMmAl5CFlPGLY94Vlcm+zWApK7F/eocsNzp8tKmbeBP8yXyAbx0XHsFNA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.52.5",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.52.5.tgz",
+      "integrity": "sha512-takF3CR71mCAGA+v794QUZ0b6ZSrgJkArC+gUiG6LB6TQty9T0Mqh3m2ImRBOxS2IeYBo4lKWIieSvnEk2OQWA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.52.5",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.52.5.tgz",
+      "integrity": "sha512-W901Pla8Ya95WpxDn//VF9K9u2JbocwV/v75TE0YIHNTbhqUTv9w4VuQ9MaWlNOkkEfFwkdNhXgcLqPSmHy0fA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.52.5",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.52.5.tgz",
+      "integrity": "sha512-QofO7i7JycsYOWxe0GFqhLmF6l1TqBswJMvICnRUjqCx8b47MTo46W8AoeQwiokAx3zVryVnxtBMcGcnX12LvA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.52.5",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.52.5.tgz",
+      "integrity": "sha512-jr21b/99ew8ujZubPo9skbrItHEIE50WdV86cdSoRkKtmWa+DDr6fu2c/xyRT0F/WazZpam6kk7IHBerSL7LDQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.52.5",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.52.5.tgz",
+      "integrity": "sha512-PsNAbcyv9CcecAUagQefwX8fQn9LQ4nZkpDboBOttmyffnInRy8R8dSg6hxxl2Re5QhHBf6FYIDhIj5v982ATQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.52.5",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.52.5.tgz",
+      "integrity": "sha512-Fw4tysRutyQc/wwkmcyoqFtJhh0u31K+Q6jYjeicsGJJ7bbEq8LwPWV/w0cnzOqR2m694/Af6hpFayLJZkG2VQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.52.5",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.52.5.tgz",
+      "integrity": "sha512-a+3wVnAYdQClOTlyapKmyI6BLPAFYs0JM8HRpgYZQO02rMR09ZcV9LbQB+NL6sljzG38869YqThrRnfPMCDtZg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.52.5",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.52.5.tgz",
+      "integrity": "sha512-AvttBOMwO9Pcuuf7m9PkC1PUIKsfaAJ4AYhy944qeTJgQOqJYJ9oVl2nYgY7Rk0mkbsuOpCAYSs6wLYB2Xiw0Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.52.5",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.52.5.tgz",
+      "integrity": "sha512-DkDk8pmXQV2wVrF6oq5tONK6UHLz/XcEVow4JTTerdeV1uqPeHxwcg7aFsfnSm9L+OO8WJsWotKM2JJPMWrQtA==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.52.5",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.52.5.tgz",
+      "integrity": "sha512-W/b9ZN/U9+hPQVvlGwjzi+Wy4xdoH2I8EjaCkMvzpI7wJUs8sWJ03Rq96jRnHkSrcHTpQe8h5Tg3ZzUPGauvAw==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.52.5",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.52.5.tgz",
+      "integrity": "sha512-sjQLr9BW7R/ZiXnQiWPkErNfLMkkWIoCz7YMn27HldKsADEKa5WYdobaa1hmN6slu9oWQbB6/jFpJ+P2IkVrmw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.52.5",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.52.5.tgz",
+      "integrity": "sha512-hq3jU/kGyjXWTvAh2awn8oHroCbrPm8JqM7RUpKjalIRWWXE01CQOf/tUNWNHjmbMHg/hmNCwc/Pz3k1T/j/Lg==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.52.5",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.52.5.tgz",
+      "integrity": "sha512-gn8kHOrku8D4NGHMK1Y7NA7INQTRdVOntt1OCYypZPRt6skGbddska44K8iocdpxHTMMNui5oH4elPH4QOLrFQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.52.5",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.52.5.tgz",
+      "integrity": "sha512-hXGLYpdhiNElzN770+H2nlx+jRog8TyynpTVzdlc6bndktjKWyZyiCsuDAlpd+j+W+WNqfcyAWz9HxxIGfZm1Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.52.5",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.52.5.tgz",
+      "integrity": "sha512-arCGIcuNKjBoKAXD+y7XomR9gY6Mw7HnFBv5Rw7wQRvwYLR7gBAgV7Mb2QTyjXfTveBNFAtPt46/36vV9STLNg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.52.5",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.52.5.tgz",
+      "integrity": "sha512-QoFqB6+/9Rly/RiPjaomPLmR/13cgkIGfA40LHly9zcH1S0bN2HVFYk3a1eAyHQyjs3ZJYlXvIGtcCs5tko9Cw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.52.5",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.52.5.tgz",
+      "integrity": "sha512-w0cDWVR6MlTstla1cIfOGyl8+qb93FlAVutcor14Gf5Md5ap5ySfQ7R9S/NjNaMLSFdUnKGEasmVnu3lCMqB7w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.52.5",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.52.5.tgz",
+      "integrity": "sha512-Aufdpzp7DpOTULJCuvzqcItSGDH73pF3ko/f+ckJhxQyHtp67rHw3HMNxoIdDMUITJESNE6a8uh4Lo4SLouOUg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.52.5",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.52.5.tgz",
+      "integrity": "sha512-UGBUGPFp1vkj6p8wCRraqNhqwX/4kNQPS57BCFc8wYh0g94iVIW33wJtQAx3G7vrjjNtRaxiMUylM0ktp/TRSQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.52.5",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.52.5.tgz",
+      "integrity": "sha512-TAcgQh2sSkykPRWLrdyy2AiceMckNf5loITqXxFI5VuQjS5tSuw3WlwdN8qv8vzjLAUTvYaH/mVjSFpbkFbpTg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.0.0.tgz",
+      "integrity": "sha512-m2bOd0f2RT9k8QJx1JN85cZYyH1RqFBdlwtkSlf4tBDYLCiiZnv1fIIwacK6cqwXavOydf0NPToMQgpKq+dVlA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/bun": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/@types/bun/-/bun-1.3.1.tgz",
@@ -471,6 +884,31 @@
       "dependencies": {
         "bun-types": "1.3.1"
       }
+    },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
+      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/keypress": {
       "version": "2.0.30",
@@ -509,6 +947,193 @@
         "csstype": "^3.0.2"
       }
     },
+    "node_modules/@vitest/coverage-v8": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-4.0.3.tgz",
+      "integrity": "sha512-I+MlLwyJRBjmJr1kFYSxoseINbIdpxIAeK10jmXgB0FUtIfdYsvM3lGAvBu5yk8WPyhefzdmbCHCc1idFbNRcg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@bcoe/v8-coverage": "^1.0.2",
+        "@vitest/utils": "4.0.3",
+        "ast-v8-to-istanbul": "^0.3.5",
+        "debug": "^4.4.3",
+        "istanbul-lib-coverage": "^3.2.2",
+        "istanbul-lib-report": "^3.0.1",
+        "istanbul-lib-source-maps": "^5.0.6",
+        "istanbul-reports": "^3.2.0",
+        "magicast": "^0.3.5",
+        "std-env": "^3.9.0",
+        "tinyrainbow": "^3.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@vitest/browser": "4.0.3",
+        "vitest": "4.0.3"
+      },
+      "peerDependenciesMeta": {
+        "@vitest/browser": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/expect": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.0.3.tgz",
+      "integrity": "sha512-v3eSDx/bF25pzar6aEJrrdTXJduEBU3uSGXHslIdGIpJVP8tQQHV6x1ZfzbFQ/bLIomLSbR/2ZCfnaEGkWkiVQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.0.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.0.3",
+        "@vitest/utils": "4.0.3",
+        "chai": "^6.0.1",
+        "tinyrainbow": "^3.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.0.3.tgz",
+      "integrity": "sha512-evZcRspIPbbiJEe748zI2BRu94ThCBE+RkjCpVF8yoVYuTV7hMe+4wLF/7K86r8GwJHSmAPnPbZhpXWWrg1qbA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.0.3",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.19"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.0.3.tgz",
+      "integrity": "sha512-N7gly/DRXzxa9w9sbDXwD9QNFYP2hw90LLLGDobPNwiWgyW95GMxsCt29/COIKKh3P7XJICR38PSDePenMBtsw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.0.3.tgz",
+      "integrity": "sha512-1/aK6fPM0lYXWyGKwop2Gbvz1plyTps/HDbIIJXYtJtspHjpXIeB3If07eWpVH4HW7Rmd3Rl+IS/+zEAXrRtXA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.0.3",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.0.3.tgz",
+      "integrity": "sha512-amnYmvZ5MTjNCP1HZmdeczAPLRD6iOm9+2nMRUGxbe/6sQ0Ymur0NnR9LIrWS8JA3wKE71X25D6ya/3LN9YytA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.0.3",
+        "magic-string": "^0.30.19",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.0.3.tgz",
+      "integrity": "sha512-82vVL8Cqz7rbXaNUl35V2G7xeNMAjBdNOVaHbrzznT9BmiCiPOzhf0FhU3eP41nP1bLDm/5wWKZqkG4nyU95DQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/ui": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/@vitest/ui/-/ui-4.0.3.tgz",
+      "integrity": "sha512-HURRrgGVzz2GQ2Imurp55FA+majHXgCXMzcwtojUZeRsAXyHNgEvxGRJf4QQY4kJeVakiugusGYeUqBgZ/xylg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.0.3",
+        "fflate": "^0.8.2",
+        "flatted": "^3.3.3",
+        "pathe": "^2.0.3",
+        "sirv": "^3.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "vitest": "4.0.3"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.0.3.tgz",
+      "integrity": "sha512-qV6KJkq8W3piW6MDIbGOmn1xhvcW4DuA07alqaQ+vdx7YA49J85pnwnxigZVQFQw3tWnQNRKWwhz5wbP6iv/GQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.0.3",
+        "tinyrainbow": "^3.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/ast-v8-to-istanbul": {
+      "version": "0.3.8",
+      "resolved": "https://registry.npmjs.org/ast-v8-to-istanbul/-/ast-v8-to-istanbul-0.3.8.tgz",
+      "integrity": "sha512-szgSZqUxI5T8mLKvS7WTjF9is+MVbOeLADU73IseOcrqhxr/VAvy6wfoVE39KnKzA7JRhjF5eUagNlHwvZPlKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.31",
+        "estree-walker": "^3.0.3",
+        "js-tokens": "^9.0.1"
+      }
+    },
     "node_modules/bun-types": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/bun-types/-/bun-types-1.3.1.tgz",
@@ -522,6 +1147,16 @@
         "@types/react": "^19"
       }
     },
+    "node_modules/chai": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.0.tgz",
+      "integrity": "sha512-aUTnJc/JipRzJrNADXVvpVqi6CO0dn3nx4EVPxijri+fj3LUUDyZQOgVeW54Ob3Y1Xh9Iz8f+CgaCl8v0mn9bA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/csstype": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
@@ -529,6 +1164,31 @@
       "dev": true,
       "license": "MIT",
       "peer": true
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/esbuild": {
       "version": "0.25.11",
@@ -572,6 +1232,51 @@
         "@esbuild/win32-x64": "0.25.11"
       }
     },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.2.2.tgz",
+      "integrity": "sha512-JhFGDVJ7tmDJItKhYgJCGLOWjuK9vPxiXoUFLwLDc99NlmklilbiQJwoctZtt13+xMw91MCk/REan6MWHqDjyA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/fflate": {
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.2.tgz",
+      "integrity": "sha512-cPJU47OaAoCbg0pBvzsgpTPhmhqI5eJjh/JIu8tPj5q+T7iLvW/JAYUqmE7KOB4R1ZyEhzBaIQpQpardBF5z8A==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/find-exec": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/find-exec/-/find-exec-1.0.3.tgz",
@@ -580,6 +1285,13 @@
       "dependencies": {
         "shell-quote": "^1.8.1"
       }
+    },
+    "node_modules/flatted": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.3.tgz",
+      "integrity": "sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/fsevents": {
       "version": "2.3.3",
@@ -609,11 +1321,190 @@
         "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
       }
     },
+    "node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/html-escaper": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
+      "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/istanbul-lib-coverage": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.2.tgz",
+      "integrity": "sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/istanbul-lib-report": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz",
+      "integrity": "sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "istanbul-lib-coverage": "^3.0.0",
+        "make-dir": "^4.0.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-lib-source-maps": {
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-5.0.6.tgz",
+      "integrity": "sha512-yg2d+Em4KizZC5niWhQaIomgf5WlL4vOOjZ5xGCmF8SnPE/mDWWXgvRExdcpCgh9lLRRa1/fSYp2ymmbJ1pI+A==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.23",
+        "debug": "^4.1.1",
+        "istanbul-lib-coverage": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-reports": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.2.0.tgz",
+      "integrity": "sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "html-escaper": "^2.0.0",
+        "istanbul-lib-report": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/js-tokens": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-9.0.1.tgz",
+      "integrity": "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/keypress": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/keypress/-/keypress-0.2.1.tgz",
       "integrity": "sha512-HjorDJFNhnM4SicvaUXac0X77NiskggxJdesG72+O5zBKpSqKFCrqmndKVqpu3pFqkla0St6uGk8Ju0sCurrmg==",
       "license": "MIT"
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/magicast": {
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/magicast/-/magicast-0.3.5.tgz",
+      "integrity": "sha512-L0WhttDl+2BOsybvEOLK7fW3UA0OQ0IQ2d6Zl2x/a6vVRs3bAY0ECOSHHeL5jD+SbOpOCUEi0y1DgHEn9Qn1AQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.25.4",
+        "@babel/types": "^7.25.4",
+        "source-map-js": "^1.2.0"
+      }
+    },
+    "node_modules/make-dir": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz",
+      "integrity": "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.5.3"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/mrmime": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/mrmime/-/mrmime-2.0.1.tgz",
+      "integrity": "sha512-Y3wQdFg2Va6etvQ5I82yUhGdsKrcYox6p7FfL1LbK2J4V01F9TGlepTIhnK24t7koZibmg82KGglhA1XK5IsLQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.11",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
+      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
+      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
     },
     "node_modules/play-sound": {
       "version": "1.1.6",
@@ -622,6 +1513,35 @@
       "license": "MIT",
       "dependencies": {
         "find-exec": "1.0.3"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.6",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
+      "integrity": "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.11",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
       }
     },
     "node_modules/resolve-pkg-maps": {
@@ -634,6 +1554,61 @@
         "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
       }
     },
+    "node_modules/rollup": {
+      "version": "4.52.5",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.52.5.tgz",
+      "integrity": "sha512-3GuObel8h7Kqdjt0gxkEzaifHTqLVW56Y/bjN7PSQtkKr0w3V/QYSdt6QWYtd7A1xUtYQigtdUfgj1RvWVtorw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.8"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.52.5",
+        "@rollup/rollup-android-arm64": "4.52.5",
+        "@rollup/rollup-darwin-arm64": "4.52.5",
+        "@rollup/rollup-darwin-x64": "4.52.5",
+        "@rollup/rollup-freebsd-arm64": "4.52.5",
+        "@rollup/rollup-freebsd-x64": "4.52.5",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.52.5",
+        "@rollup/rollup-linux-arm-musleabihf": "4.52.5",
+        "@rollup/rollup-linux-arm64-gnu": "4.52.5",
+        "@rollup/rollup-linux-arm64-musl": "4.52.5",
+        "@rollup/rollup-linux-loong64-gnu": "4.52.5",
+        "@rollup/rollup-linux-ppc64-gnu": "4.52.5",
+        "@rollup/rollup-linux-riscv64-gnu": "4.52.5",
+        "@rollup/rollup-linux-riscv64-musl": "4.52.5",
+        "@rollup/rollup-linux-s390x-gnu": "4.52.5",
+        "@rollup/rollup-linux-x64-gnu": "4.52.5",
+        "@rollup/rollup-linux-x64-musl": "4.52.5",
+        "@rollup/rollup-openharmony-arm64": "4.52.5",
+        "@rollup/rollup-win32-arm64-msvc": "4.52.5",
+        "@rollup/rollup-win32-ia32-msvc": "4.52.5",
+        "@rollup/rollup-win32-x64-gnu": "4.52.5",
+        "@rollup/rollup-win32-x64-msvc": "4.52.5",
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/semver": {
+      "version": "7.7.3",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
+      "integrity": "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/shell-quote": {
       "version": "1.8.3",
       "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.3.tgz",
@@ -644,6 +1619,116 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/sirv": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/sirv/-/sirv-3.0.2.tgz",
+      "integrity": "sha512-2wcC/oGxHis/BoHkkPwldgiPSYcpZK3JU28WoMVv55yHJgcZ8rlXvuG9iZggz+sU1d4bRgIGASwyWqjxu3FM0g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@polka/url": "^1.0.0-next.24",
+        "mrmime": "^2.0.0",
+        "totalist": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
+      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
+      "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.15",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
+      "integrity": "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.3"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.0.3.tgz",
+      "integrity": "sha512-PSkbLUoxOFRzJYjjxHJt9xro7D+iilgMX/C9lawzVuYiIdcihh9DXmVibBe8lmcFrRi/VzlPjBxbN7rH24q8/Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/totalist": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/totalist/-/totalist-3.0.1.tgz",
+      "integrity": "sha512-sf4i37nQ2LBx4m3wB74y+ubopq6W/dIzXg0FDGjsYnZHVa1Da8FH853wlL2gtUhg+xJXjfk3kUZS3BRoQeoQBQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/tsx": {
@@ -671,6 +1756,176 @@
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
       "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
       "license": "MIT"
+    },
+    "node_modules/vite": {
+      "version": "7.1.12",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-7.1.12.tgz",
+      "integrity": "sha512-ZWyE8YXEXqJrrSLvYgrRP7p62OziLW7xI5HYGWFzOvupfAlrLvURSzv/FyGyy0eidogEM3ujU+kUG1zuHgb6Ug==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.25.0",
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.3",
+        "postcss": "^8.5.6",
+        "rollup": "^4.43.0",
+        "tinyglobby": "^0.2.15"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "lightningcss": "^1.21.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitest": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.0.3.tgz",
+      "integrity": "sha512-IUSop8jgaT7w0g1yOM/35qVtKjr/8Va4PrjzH1OUb0YH4c3OXB2lCZDkMAB6glA8T5w8S164oJGsbcmAecr4sA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.0.3",
+        "@vitest/mocker": "4.0.3",
+        "@vitest/pretty-format": "4.0.3",
+        "@vitest/runner": "4.0.3",
+        "@vitest/snapshot": "4.0.3",
+        "@vitest/spy": "4.0.3",
+        "@vitest/utils": "4.0.3",
+        "debug": "^4.4.3",
+        "es-module-lexer": "^1.7.0",
+        "expect-type": "^1.2.2",
+        "magic-string": "^0.30.19",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^3.9.0",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^0.3.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.0.3",
+        "vite": "^6.0.0 || ^7.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@types/debug": "^4.1.12",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.0.3",
+        "@vitest/browser-preview": "4.0.3",
+        "@vitest/browser-webdriverio": "4.0.3",
+        "@vitest/ui": "4.0.3",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@types/debug": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -7,7 +7,11 @@
   "scripts": {
     "start": "bun run index.ts",
     "dev": "bun --watch index.ts",
-    "type-check": "tsc --noEmit"
+    "type-check": "tsc --noEmit",
+    "test": "vitest",
+    "test:ui": "vitest --ui",
+    "test:coverage": "vitest --coverage",
+    "test:run": "vitest run"
   },
   "dependencies": {
     "@types/play-sound": "^1.1.2",
@@ -18,7 +22,10 @@
     "@types/bun": "^1.3.1",
     "@types/keypress": "^2.0.30",
     "@types/node": "^20.10.0",
+    "@vitest/coverage-v8": "^4.0.3",
+    "@vitest/ui": "^4.0.3",
     "bun-types": "^1.0.0",
-    "tsx": "^4.20.6"
+    "tsx": "^4.20.6",
+    "vitest": "^4.0.3"
   }
 }

--- a/src/core/__tests__/game-logic.test.ts
+++ b/src/core/__tests__/game-logic.test.ts
@@ -1,13 +1,9 @@
 /**
- * Example test file demonstrating testability improvements
+ * Tests for game-logic module
  * These are pure function tests - NO MOCKS NEEDED!
- *
- * To run these tests, install a test runner like Vitest or Jest:
- *   npm install --save-dev vitest
- *   npx vitest
  */
 
-import { describe, it, expect } from 'vitest'; // or 'jest' or 'bun:test'
+import { describe, it, expect } from 'vitest';
 import {
 	createInitialGameState,
 	processKeypress,
@@ -107,11 +103,11 @@ describe('game-logic (pure functions)', () => {
 	});
 });
 
-// Example: Testing with mocked adapters (integration-style test)
+// Testing with mocked adapters (integration-style test)
 describe('adapters integration', () => {
-	it('should allow testing with mock sound adapter', () => {
-		// Import the mock adapter
-		const { createMockSoundAdapter } = require('../../adapters/sound-adapter.js');
+	it('should allow testing with mock sound adapter', async () => {
+		// Dynamic import the mock adapter
+		const { createMockSoundAdapter } = await import('../../adapters/sound-adapter.js');
 		const mockSound = createMockSoundAdapter();
 
 		// Use it

--- a/src/core/__tests__/level-progression.test.ts
+++ b/src/core/__tests__/level-progression.test.ts
@@ -1,0 +1,243 @@
+/**
+ * Tests for level-progression module
+ * Tests pure functions for level progression and management
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+	createShuffledLevelIndices,
+	getActualLevel,
+	hasNextLevel,
+	getNextLevelIndex,
+	type Level,
+} from '../level-progression.js';
+
+describe('level-progression', () => {
+	// Mock levels for testing
+	const mockLevels: Level[] = [
+		{ target: 'first' },
+		{ target: 'second' },
+		{ target: 'third' },
+		{ target: 'fourth' },
+		{ target: 'fifth' },
+	];
+
+	describe('createShuffledLevelIndices', () => {
+		it('should return array with same length as input', () => {
+			const result = createShuffledLevelIndices(mockLevels);
+
+			expect(result.length).toBe(mockLevels.length);
+		});
+
+		it('should return all indices from 0 to length-1', () => {
+			const result = createShuffledLevelIndices(mockLevels);
+
+			expect(result.sort()).toEqual([0, 1, 2, 3, 4]);
+		});
+
+		it('should handle single level', () => {
+			const singleLevel = [{ target: 'only' }];
+			const result = createShuffledLevelIndices(singleLevel);
+
+			expect(result).toEqual([0]);
+		});
+
+		it('should handle empty level array', () => {
+			const result = createShuffledLevelIndices([]);
+
+			expect(result).toEqual([]);
+		});
+
+		it('should produce different orders on multiple calls (probabilistic)', () => {
+			const results = new Set();
+
+			// Run multiple times to check randomization
+			for (let i = 0; i < 10; i++) {
+				const shuffled = createShuffledLevelIndices(mockLevels);
+				results.add(shuffled.join(','));
+			}
+
+			// With 5 levels, very unlikely to get the same order 10 times
+			expect(results.size).toBeGreaterThan(1);
+		});
+
+		it('should not modify original levels array', () => {
+			const original = [...mockLevels];
+
+			createShuffledLevelIndices(mockLevels);
+
+			expect(mockLevels).toEqual(original);
+		});
+
+		it('should work with two levels', () => {
+			const twoLevels = [{ target: 'a' }, { target: 'b' }];
+			const result = createShuffledLevelIndices(twoLevels);
+
+			expect(result.length).toBe(2);
+			expect(result.sort()).toEqual([0, 1]);
+		});
+	});
+
+	describe('getActualLevel', () => {
+		it('should return correct level based on shuffled index', () => {
+			const shuffledIndices = [2, 0, 4, 1, 3]; // Specific shuffle order
+
+			const level = getActualLevel(shuffledIndices, 0, mockLevels);
+
+			expect(level).toEqual({ target: 'third' }); // Index 2
+		});
+
+		it('should work for different positions', () => {
+			const shuffledIndices = [2, 0, 4, 1, 3];
+
+			expect(getActualLevel(shuffledIndices, 0, mockLevels).target).toBe('third');
+			expect(getActualLevel(shuffledIndices, 1, mockLevels).target).toBe('first');
+			expect(getActualLevel(shuffledIndices, 2, mockLevels).target).toBe('fifth');
+			expect(getActualLevel(shuffledIndices, 3, mockLevels).target).toBe('second');
+			expect(getActualLevel(shuffledIndices, 4, mockLevels).target).toBe('fourth');
+		});
+
+		it('should work with sequential indices', () => {
+			const sequentialIndices = [0, 1, 2, 3, 4]; // No shuffle
+
+			const level = getActualLevel(sequentialIndices, 2, mockLevels);
+
+			expect(level).toEqual({ target: 'third' });
+		});
+
+		it('should work with single level', () => {
+			const singleLevel = [{ target: 'only' }];
+			const indices = [0];
+
+			const level = getActualLevel(indices, 0, singleLevel);
+
+			expect(level).toEqual({ target: 'only' });
+		});
+
+		it('should work at first position', () => {
+			const shuffledIndices = [4, 3, 2, 1, 0]; // Reversed
+
+			const level = getActualLevel(shuffledIndices, 0, mockLevels);
+
+			expect(level.target).toBe('fifth');
+		});
+
+		it('should work at last position', () => {
+			const shuffledIndices = [4, 3, 2, 1, 0]; // Reversed
+
+			const level = getActualLevel(shuffledIndices, 4, mockLevels);
+
+			expect(level.target).toBe('first');
+		});
+	});
+
+	describe('hasNextLevel', () => {
+		it('should return true when not at last level', () => {
+			expect(hasNextLevel(0, 5)).toBe(true);
+			expect(hasNextLevel(1, 5)).toBe(true);
+			expect(hasNextLevel(2, 5)).toBe(true);
+			expect(hasNextLevel(3, 5)).toBe(true);
+		});
+
+		it('should return false when at last level', () => {
+			expect(hasNextLevel(4, 5)).toBe(false);
+		});
+
+		it('should work with single level', () => {
+			expect(hasNextLevel(0, 1)).toBe(false);
+		});
+
+		it('should work with two levels', () => {
+			expect(hasNextLevel(0, 2)).toBe(true);
+			expect(hasNextLevel(1, 2)).toBe(false);
+		});
+
+		it('should work at boundary', () => {
+			expect(hasNextLevel(98, 100)).toBe(true);
+			expect(hasNextLevel(99, 100)).toBe(false);
+		});
+
+		it('should handle zero levels edge case', () => {
+			expect(hasNextLevel(0, 0)).toBe(false);
+		});
+	});
+
+	describe('getNextLevelIndex', () => {
+		it('should increment by one', () => {
+			expect(getNextLevelIndex(0)).toBe(1);
+			expect(getNextLevelIndex(1)).toBe(2);
+			expect(getNextLevelIndex(2)).toBe(3);
+		});
+
+		it('should work from any index', () => {
+			expect(getNextLevelIndex(10)).toBe(11);
+			expect(getNextLevelIndex(99)).toBe(100);
+		});
+
+		it('should work with negative index (though not expected in practice)', () => {
+			expect(getNextLevelIndex(-1)).toBe(0);
+		});
+
+		it('should be pure function - same input produces same output', () => {
+			const index = 5;
+
+			const result1 = getNextLevelIndex(index);
+			const result2 = getNextLevelIndex(index);
+
+			expect(result1).toBe(result2);
+			expect(result1).toBe(6);
+		});
+	});
+
+	describe('integration: level progression flow', () => {
+		it('should allow complete traversal of all levels', () => {
+			const shuffledIndices = createShuffledLevelIndices(mockLevels);
+			const visitedLevels: string[] = [];
+			let currentIndex = 0;
+
+			// Traverse all levels
+			while (currentIndex < mockLevels.length) {
+				const level = getActualLevel(shuffledIndices, currentIndex, mockLevels);
+				visitedLevels.push(level.target);
+
+				if (hasNextLevel(currentIndex, mockLevels.length)) {
+					currentIndex = getNextLevelIndex(currentIndex);
+				} else {
+					break;
+				}
+			}
+
+			// Should visit all 5 levels
+			expect(visitedLevels.length).toBe(5);
+
+			// Should visit each level exactly once (order may vary)
+			expect(visitedLevels.sort()).toEqual(['fifth', 'first', 'fourth', 'second', 'third']);
+		});
+
+		it('should stop at last level', () => {
+			const shuffledIndices = [0, 1, 2];
+			const levels: Level[] = [
+				{ target: 'a' },
+				{ target: 'b' },
+				{ target: 'c' },
+			];
+
+			let currentIndex = 0;
+			const visitedCount = [];
+
+			while (true) {
+				getActualLevel(shuffledIndices, currentIndex, levels);
+				visitedCount.push(currentIndex);
+
+				if (!hasNextLevel(currentIndex, levels.length)) {
+					break;
+				}
+
+				currentIndex = getNextLevelIndex(currentIndex);
+			}
+
+			expect(visitedCount).toEqual([0, 1, 2]);
+			expect(currentIndex).toBe(2);
+		});
+	});
+});

--- a/src/core/__tests__/score-calculator.test.ts
+++ b/src/core/__tests__/score-calculator.test.ts
@@ -1,0 +1,243 @@
+/**
+ * Tests for score-calculator module
+ * Tests pure functions for score calculation and performance evaluation
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+	isPerfect,
+	calculateStats,
+	generateFeedback,
+	type PerformanceStats,
+} from '../score-calculator.js';
+
+describe('score-calculator', () => {
+	describe('isPerfect', () => {
+		it('should return true when no errors and no missed letters', () => {
+			expect(isPerfect(0, 0)).toBe(true);
+		});
+
+		it('should return false when there are errors', () => {
+			expect(isPerfect(1, 0)).toBe(false);
+			expect(isPerfect(5, 0)).toBe(false);
+		});
+
+		it('should return false when there are missed letters', () => {
+			expect(isPerfect(0, 1)).toBe(false);
+			expect(isPerfect(0, 10)).toBe(false);
+		});
+
+		it('should return false when both errors and missed letters exist', () => {
+			expect(isPerfect(1, 1)).toBe(false);
+			expect(isPerfect(5, 3)).toBe(false);
+		});
+	});
+
+	describe('calculateStats', () => {
+		it('should calculate stats for perfect performance', () => {
+			const stats = calculateStats(0, 0);
+
+			expect(stats.errorCount).toBe(0);
+			expect(stats.missedLetters).toBe(0);
+			expect(stats.isPerfect).toBe(true);
+		});
+
+		it('should calculate stats with errors', () => {
+			const stats = calculateStats(5, 0);
+
+			expect(stats.errorCount).toBe(5);
+			expect(stats.missedLetters).toBe(0);
+			expect(stats.isPerfect).toBe(false);
+		});
+
+		it('should calculate stats with missed letters', () => {
+			const stats = calculateStats(0, 3);
+
+			expect(stats.errorCount).toBe(0);
+			expect(stats.missedLetters).toBe(3);
+			expect(stats.isPerfect).toBe(false);
+		});
+
+		it('should calculate stats with both errors and misses', () => {
+			const stats = calculateStats(2, 4);
+
+			expect(stats.errorCount).toBe(2);
+			expect(stats.missedLetters).toBe(4);
+			expect(stats.isPerfect).toBe(false);
+		});
+	});
+
+	describe('generateFeedback', () => {
+		describe('perfect performance feedback', () => {
+			it('should return perfect message when no errors or misses', () => {
+				const stats: PerformanceStats = {
+					errorCount: 0,
+					missedLetters: 0,
+					isPerfect: true,
+				};
+
+				const feedback = generateFeedback(stats);
+
+				expect(feedback.type).toBe('perfect');
+				expect(feedback.message).toBe('Engar villur og náðir hverjum staf í fyrstu tilraun!');
+			});
+		});
+
+		describe('good-accuracy feedback', () => {
+			it('should return good-accuracy message when no errors but some misses', () => {
+				const stats: PerformanceStats = {
+					errorCount: 0,
+					missedLetters: 3,
+					isPerfect: false,
+				};
+
+				const feedback = generateFeedback(stats);
+
+				expect(feedback.type).toBe('good-accuracy');
+				expect(feedback.message).toBe('Frábær nákvæmni! Reyndu að ná stöfum hraðar næst.');
+			});
+
+			it('should work with just one missed letter', () => {
+				const stats: PerformanceStats = {
+					errorCount: 0,
+					missedLetters: 1,
+					isPerfect: false,
+				};
+
+				const feedback = generateFeedback(stats);
+
+				expect(feedback.type).toBe('good-accuracy');
+			});
+
+			it('should work with many missed letters', () => {
+				const stats: PerformanceStats = {
+					errorCount: 0,
+					missedLetters: 100,
+					isPerfect: false,
+				};
+
+				const feedback = generateFeedback(stats);
+
+				expect(feedback.type).toBe('good-accuracy');
+			});
+		});
+
+		describe('good-efficiency feedback', () => {
+			it('should return good-efficiency message when errors but no misses', () => {
+				const stats: PerformanceStats = {
+					errorCount: 2,
+					missedLetters: 0,
+					isPerfect: false,
+				};
+
+				const feedback = generateFeedback(stats);
+
+				expect(feedback.type).toBe('good-efficiency');
+				expect(feedback.message).toBe('Fullkomin skilvirkni! Einbeittu þér að því að fækka villum.');
+			});
+
+			it('should work with just one error', () => {
+				const stats: PerformanceStats = {
+					errorCount: 1,
+					missedLetters: 0,
+					isPerfect: false,
+				};
+
+				const feedback = generateFeedback(stats);
+
+				expect(feedback.type).toBe('good-efficiency');
+			});
+
+			it('should work with many errors', () => {
+				const stats: PerformanceStats = {
+					errorCount: 50,
+					missedLetters: 0,
+					isPerfect: false,
+				};
+
+				const feedback = generateFeedback(stats);
+
+				expect(feedback.type).toBe('good-efficiency');
+			});
+		});
+
+		describe('keep-practicing feedback', () => {
+			it('should return keep-practicing message when both errors and misses', () => {
+				const stats: PerformanceStats = {
+					errorCount: 3,
+					missedLetters: 2,
+					isPerfect: false,
+				};
+
+				const feedback = generateFeedback(stats);
+
+				expect(feedback.type).toBe('keep-practicing');
+				expect(feedback.message).toBe('Haltu áfram að æfa til að ná fullkomnum árangri!');
+			});
+
+			it('should work with minimal errors and misses', () => {
+				const stats: PerformanceStats = {
+					errorCount: 1,
+					missedLetters: 1,
+					isPerfect: false,
+				};
+
+				const feedback = generateFeedback(stats);
+
+				expect(feedback.type).toBe('keep-practicing');
+			});
+
+			it('should work with many errors and misses', () => {
+				const stats: PerformanceStats = {
+					errorCount: 100,
+					missedLetters: 100,
+					isPerfect: false,
+				};
+
+				const feedback = generateFeedback(stats);
+
+				expect(feedback.type).toBe('keep-practicing');
+			});
+		});
+
+		describe('feedback type coverage', () => {
+			it('should cover all four feedback types', () => {
+				const feedbackTypes = new Set<string>();
+
+				// Perfect
+				feedbackTypes.add(generateFeedback({
+					errorCount: 0,
+					missedLetters: 0,
+					isPerfect: true,
+				}).type);
+
+				// Good accuracy
+				feedbackTypes.add(generateFeedback({
+					errorCount: 0,
+					missedLetters: 1,
+					isPerfect: false,
+				}).type);
+
+				// Good efficiency
+				feedbackTypes.add(generateFeedback({
+					errorCount: 1,
+					missedLetters: 0,
+					isPerfect: false,
+				}).type);
+
+				// Keep practicing
+				feedbackTypes.add(generateFeedback({
+					errorCount: 1,
+					missedLetters: 1,
+					isPerfect: false,
+				}).type);
+
+				expect(feedbackTypes.size).toBe(4);
+				expect(feedbackTypes.has('perfect')).toBe(true);
+				expect(feedbackTypes.has('good-accuracy')).toBe(true);
+				expect(feedbackTypes.has('good-efficiency')).toBe(true);
+				expect(feedbackTypes.has('keep-practicing')).toBe(true);
+			});
+		});
+	});
+});

--- a/src/core/__tests__/word-generation.test.ts
+++ b/src/core/__tests__/word-generation.test.ts
@@ -1,0 +1,276 @@
+/**
+ * Tests for word-generation module
+ * Tests pure functions for word manipulation and character generation
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import {
+	split,
+	mix,
+	generateBagOfChars,
+	shuffleArray,
+} from '../word-generation.js';
+
+describe('word-generation', () => {
+	describe('split', () => {
+		it('should split single word into individual characters', () => {
+			const result = split('hello');
+			expect(result).toEqual(['h', 'e', 'l', 'l', 'o']);
+		});
+
+		it('should split phrase with spaces by spaces', () => {
+			const result = split('hello world');
+			expect(result).toEqual(['hello', 'world']);
+		});
+
+		it('should handle multiple spaces correctly', () => {
+			const result = split('one two three');
+			expect(result).toEqual(['one', 'two', 'three']);
+		});
+
+		it('should handle single character', () => {
+			const result = split('a');
+			expect(result).toEqual(['a']);
+		});
+
+		it('should handle empty string', () => {
+			const result = split('');
+			expect(result).toEqual([]);
+		});
+	});
+
+	describe('mix', () => {
+		it('should add target word parts 4 times', () => {
+			const splitWord = ['a', 'b'];
+			const alphabet = ['x', 'y', 'z'];
+			const result = mix(splitWord, alphabet);
+
+			// Count occurrences of 'a' and 'b'
+			const aCount = result.filter(c => c === 'a').length;
+			const bCount = result.filter(c => c === 'b').length;
+
+			expect(aCount).toBe(4);
+			expect(bCount).toBe(4);
+		});
+
+		it('should add alphabet once', () => {
+			const splitWord = ['a'];
+			const alphabet = ['x', 'y', 'z'];
+			const result = mix(splitWord, alphabet);
+
+			// Count occurrences of alphabet letters
+			const xCount = result.filter(c => c === 'x').length;
+			const yCount = result.filter(c => c === 'y').length;
+			const zCount = result.filter(c => c === 'z').length;
+
+			expect(xCount).toBe(1);
+			expect(yCount).toBe(1);
+			expect(zCount).toBe(1);
+		});
+
+		it('should add spaces based on selection length', () => {
+			const splitWord = ['a', 'b', 'c'];
+			const alphabet = ['x', 'y', 'z'];
+			const result = mix(splitWord, alphabet);
+
+			// Selection: 3 target chars + 3 alphabet + 3*3 more target = 15
+			// Spaces: floor(15 / 3) = 5
+			const spaceCount = result.filter(c => c === ' ').length;
+			const expectedSpaces = Math.floor((splitWord.length + alphabet.length + splitWord.length * 3) / 3);
+
+			expect(spaceCount).toBe(expectedSpaces);
+		});
+
+		it('should handle empty arrays', () => {
+			const result = mix([], []);
+			expect(result.length).toBeGreaterThanOrEqual(0);
+		});
+	});
+
+	describe('generateBagOfChars', () => {
+		describe('FR-001: Next required letter probability', () => {
+			it('should add next required letter 10 times for high probability', () => {
+				const result = generateBagOfChars('', 'test');
+
+				// Next letter is 't', should appear 10 times
+				const tCount = result.filter(c => c === 't').length;
+				expect(tCount).toBe(10);
+			});
+
+			it('should prioritize the immediate next letter after progress', () => {
+				const result = generateBagOfChars('te', 'test');
+
+				// Next letter is 's', should appear 10 times
+				const sCount = result.filter(c => c === 's').length;
+				expect(sCount).toBe(10);
+			});
+
+			it('should update priority as user progresses', () => {
+				const result = generateBagOfChars('tes', 'test');
+
+				// Next letter is 't' (last one), should appear 10 times
+				const tCount = result.filter(c => c === 't').length;
+				expect(tCount).toBe(10);
+			});
+		});
+
+		describe('FR-002: Only include remaining letters', () => {
+			it('should only include letters still needed in target', () => {
+				const result = generateBagOfChars('te', 'test');
+
+				// Remaining letters are 's' and 't'
+				// Should NOT contain 'e' since it's already typed
+				const eCount = result.filter(c => c === 'e').length;
+				expect(eCount).toBe(0);
+			});
+
+			it('should include non-next remaining letters 2 times each', () => {
+				const result = generateBagOfChars('', 'test');
+
+				// Next is 't' (10 times), others should be 2 times each
+				// Remaining unique letters: e, s (and t but counted separately)
+				const eCount = result.filter(c => c === 'e').length;
+				const sCount = result.filter(c => c === 's').length;
+
+				expect(eCount).toBe(2);
+				expect(sCount).toBe(2);
+			});
+
+			it('should handle duplicates in target word correctly', () => {
+				const result = generateBagOfChars('', 'book');
+
+				// Next is 'b' (10 times)
+				// Remaining: o (twice in word), k (once)
+				const bCount = result.filter(c => c === 'b').length;
+				const oCount = result.filter(c => c === 'o').length;
+				const kCount = result.filter(c => c === 'k').length;
+
+				expect(bCount).toBe(10); // Next letter
+				expect(oCount).toBe(2); // Remaining letter
+				expect(kCount).toBe(2); // Remaining letter
+			});
+
+			it('should not include letters not in the target', () => {
+				const result = generateBagOfChars('', 'abc');
+
+				// Should only contain 'a', 'b', 'c', and spaces
+				const nonTargetLetters = result.filter(c =>
+					c !== 'a' && c !== 'b' && c !== 'c' && c !== ' '
+				);
+
+				expect(nonTargetLetters.length).toBe(0);
+			});
+		});
+
+		describe('Edge cases', () => {
+			it('should return space when target is complete', () => {
+				const result = generateBagOfChars('complete', 'complete');
+
+				expect(result).toEqual([' ']);
+			});
+
+			it('should handle single character target', () => {
+				const result = generateBagOfChars('', 'a');
+
+				const aCount = result.filter(c => c === 'a').length;
+				expect(aCount).toBe(10);
+			});
+
+			it('should add spaces proportional to selection size', () => {
+				const result = generateBagOfChars('', 'test');
+
+				const spaceCount = result.filter(c => c === ' ').length;
+				const nonSpaceCount = result.filter(c => c !== ' ').length;
+
+				// Spaces should be floor(selection.length / 4)
+				const expectedSpaces = Math.floor(nonSpaceCount / 4);
+				expect(spaceCount).toBe(expectedSpaces);
+			});
+
+			it('should handle case-insensitive targets', () => {
+				const result = generateBagOfChars('', 'Test');
+
+				// Should work with lowercase
+				const tCount = result.filter(c => c === 't').length;
+				expect(tCount).toBe(10);
+			});
+
+			it('should not add space letters to selection beyond spacing', () => {
+				const result = generateBagOfChars('', 'hello world');
+
+				// Spaces should only be added at the end for gaps
+				// Not as part of the letter selection
+				const h = result[0];
+				expect(h).toBeDefined();
+			});
+		});
+	});
+
+	describe('shuffleArray', () => {
+		it('should return array with same length', () => {
+			const input = [1, 2, 3, 4, 5];
+			const result = shuffleArray(input);
+
+			expect(result.length).toBe(input.length);
+		});
+
+		it('should return array with same elements', () => {
+			const input = [1, 2, 3, 4, 5];
+			const result = shuffleArray(input);
+
+			expect(result.sort()).toEqual(input.sort());
+		});
+
+		it('should not modify original array', () => {
+			const input = [1, 2, 3, 4, 5];
+			const original = [...input];
+
+			shuffleArray(input);
+
+			expect(input).toEqual(original);
+		});
+
+		it('should handle single element array', () => {
+			const input = [1];
+			const result = shuffleArray(input);
+
+			expect(result).toEqual([1]);
+		});
+
+		it('should handle empty array', () => {
+			const input: number[] = [];
+			const result = shuffleArray(input);
+
+			expect(result).toEqual([]);
+		});
+
+		it('should produce different orders on multiple calls (probabilistic)', () => {
+			const input = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
+
+			// Run multiple times and check if we get different results
+			const results = new Set();
+			for (let i = 0; i < 10; i++) {
+				results.add(shuffleArray(input).join(','));
+			}
+
+			// With 10 elements, very unlikely to get same order 10 times
+			expect(results.size).toBeGreaterThan(1);
+		});
+
+		it('should work with strings', () => {
+			const input = ['a', 'b', 'c'];
+			const result = shuffleArray(input);
+
+			expect(result.length).toBe(3);
+			expect(result.sort()).toEqual(['a', 'b', 'c']);
+		});
+
+		it('should work with objects', () => {
+			const input = [{ id: 1 }, { id: 2 }, { id: 3 }];
+			const result = shuffleArray(input);
+
+			expect(result.length).toBe(3);
+			expect(result.map(o => o.id).sort()).toEqual([1, 2, 3]);
+		});
+	});
+});

--- a/src/presentation/__tests__/formatters.test.ts
+++ b/src/presentation/__tests__/formatters.test.ts
@@ -1,0 +1,489 @@
+/**
+ * Tests for formatters module
+ * Tests pure formatting functions for rendering
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+	getCenteringInfo,
+	createFramedLine,
+	createHorizontalBorder,
+	formatGameBoard,
+	formatProgress,
+	formatStats,
+	buildGameScreen,
+	buildWelcomeScreen,
+	buildCompletionScreen,
+	buildAllCompleteScreen,
+	buildNextLevelScreen,
+	buildGoodbyeScreen,
+	renderWithFrame,
+} from '../formatters.js';
+import type { GameState, BoardItem } from '../../core/game-logic.js';
+import type { PerformanceStats, FeedbackMessage } from '../../core/score-calculator.js';
+
+describe('formatters', () => {
+	describe('getCenteringInfo', () => {
+		it('should calculate left padding for centered content', () => {
+			const result = getCenteringInfo(50, 20, 100, 40);
+
+			expect(result.leftPadding).toBe(25); // (100 - 50) / 2
+			expect(result.topPadding).toBe(10); // (40 - 20) / 2
+		});
+
+		it('should return 0 padding when content is larger than terminal', () => {
+			const result = getCenteringInfo(150, 50, 100, 40);
+
+			expect(result.leftPadding).toBe(0);
+			expect(result.topPadding).toBe(0);
+		});
+
+		it('should handle exact fit', () => {
+			const result = getCenteringInfo(100, 40, 100, 40);
+
+			expect(result.leftPadding).toBe(0);
+			expect(result.topPadding).toBe(0);
+		});
+
+		it('should return terminal dimensions', () => {
+			const result = getCenteringInfo(50, 20, 100, 40);
+
+			expect(result.termWidth).toBe(100);
+			expect(result.termHeight).toBe(40);
+		});
+
+		it('should handle small terminal', () => {
+			const result = getCenteringInfo(10, 5, 20, 10);
+
+			expect(result.leftPadding).toBe(5);
+			expect(result.topPadding).toBe(2); // floor((10-5)/2) = 2
+		});
+
+		it('should floor odd divisions', () => {
+			const result = getCenteringInfo(49, 19, 100, 40);
+
+			expect(result.leftPadding).toBe(25); // floor((100-49)/2) = 25
+			expect(result.topPadding).toBe(10); // floor((40-19)/2) = 10
+		});
+	});
+
+	describe('createFramedLine', () => {
+		it('should create line with vertical borders', () => {
+			const result = createFramedLine('test', 10, 0);
+
+			expect(result).toContain('test');
+			// Should contain vertical frame characters
+		});
+
+		it('should add left padding', () => {
+			const result = createFramedLine('test', 10, 5);
+
+			expect(result.startsWith('     ')).toBe(true); // 5 spaces
+		});
+
+		it('should handle empty content', () => {
+			const result = createFramedLine('', 10, 0);
+
+			expect(result).toBeDefined();
+			expect(result.length).toBeGreaterThan(0);
+		});
+
+		it('should strip ANSI codes when measuring content length', () => {
+			const withAnsi = '\x1b[31mred text\x1b[0m';
+			const result = createFramedLine(withAnsi, 20, 0);
+
+			// Should measure "red text" (8 chars) not including ANSI codes
+			expect(result).toBeDefined();
+		});
+
+		it('should pad content to width', () => {
+			const result = createFramedLine('hi', 20, 0);
+
+			// Should pad the content to fill the width
+			expect(result.length).toBeGreaterThan(10);
+		});
+	});
+
+	describe('createHorizontalBorder', () => {
+		it('should create top border', () => {
+			const result = createHorizontalBorder(10, 0, true);
+
+			expect(result).toBeDefined();
+			// Top border should use topLeft and topRight
+		});
+
+		it('should create bottom border', () => {
+			const result = createHorizontalBorder(10, 0, false);
+
+			expect(result).toBeDefined();
+			// Bottom border should use bottomLeft and bottomRight
+		});
+
+		it('should add left padding', () => {
+			const result = createHorizontalBorder(10, 5, true);
+
+			expect(result.startsWith('     ')).toBe(true); // 5 spaces
+		});
+
+		it('should scale with width', () => {
+			const narrow = createHorizontalBorder(5, 0, true);
+			const wide = createHorizontalBorder(50, 0, true);
+
+			expect(wide.length).toBeGreaterThan(narrow.length);
+		});
+	});
+
+	describe('formatGameBoard', () => {
+		const CATCH_LINE = 13;
+
+		it('should format empty board', () => {
+			const board: (BoardItem | undefined)[] = new Array(16);
+			const result = formatGameBoard(board, CATCH_LINE);
+
+			expect(result.length).toBeLessThanOrEqual(16);
+		});
+
+		it('should show catch character at catch line position', () => {
+			const board: (BoardItem | undefined)[] = new Array(16);
+			const result = formatGameBoard(board, CATCH_LINE);
+
+			// Line at CATCH_LINE index should have the catch marker
+			expect(result[CATCH_LINE]).toContain('▶');
+		});
+
+		it('should mark successful letters at catch line', () => {
+			const board: (BoardItem | undefined)[] = new Array(16);
+			board[CATCH_LINE] = { generated: 'a', success: true };
+
+			const result = formatGameBoard(board, CATCH_LINE);
+
+			// Should contain the letter and success marker
+			expect(result[CATCH_LINE]).toContain('a');
+			expect(result[CATCH_LINE]).toContain('✓');
+		});
+
+		it('should mark unsuccessful letters at catch line', () => {
+			const board: (BoardItem | undefined)[] = new Array(16);
+			board[CATCH_LINE] = { generated: 'b', success: false };
+
+			const result = formatGameBoard(board, CATCH_LINE);
+
+			// Should contain the letter and catch marker
+			expect(result[CATCH_LINE]).toContain('b');
+			expect(result[CATCH_LINE]).toContain('▶');
+		});
+
+		it('should format letters before catch line', () => {
+			const board: (BoardItem | undefined)[] = new Array(16);
+			board[0] = { generated: 'x', success: false };
+			board[5] = { generated: 'y', success: false };
+
+			const result = formatGameBoard(board, CATCH_LINE);
+
+			expect(result[0]).toContain('x');
+			expect(result[5]).toContain('y');
+		});
+
+		it('should not render positions after catch line', () => {
+			const board: (BoardItem | undefined)[] = new Array(16);
+			board[14] = { generated: 'z', success: false };
+			board[15] = { generated: 'w', success: false };
+
+			const result = formatGameBoard(board, CATCH_LINE);
+
+			// Should not include positions 14 and 15
+			expect(result.length).toBe(CATCH_LINE + 1);
+		});
+	});
+
+	describe('formatProgress', () => {
+		it('should show typed progress and remaining', () => {
+			const result = formatProgress('hel', 'hello');
+
+			expect(result).toContain('hel');
+			expect(result).toContain('lo');
+		});
+
+		it('should handle empty progress', () => {
+			const result = formatProgress('', 'hello');
+
+			expect(result).toContain('hello');
+		});
+
+		it('should handle complete progress', () => {
+			const result = formatProgress('hello', 'hello');
+
+			expect(result).toContain('hello');
+		});
+
+		it('should use brackets for typed part', () => {
+			const result = formatProgress('test', 'testing');
+
+			expect(result).toContain('[test]');
+		});
+	});
+
+	describe('formatStats', () => {
+		it('should show error count and missed letters', () => {
+			const result = formatStats(5, 3);
+
+			expect(result).toContain('5');
+			expect(result).toContain('3');
+		});
+
+		it('should handle zero stats', () => {
+			const result = formatStats(0, 0);
+
+			expect(result).toContain('0');
+		});
+
+		it('should handle large numbers', () => {
+			const result = formatStats(999, 888);
+
+			expect(result).toContain('999');
+			expect(result).toContain('888');
+		});
+	});
+
+	describe('buildGameScreen', () => {
+		const mockState: GameState = {
+			board: new Array(16),
+			typedProgress: 'tes',
+			errorCount: 2,
+			missedLetters: 1,
+			catchCount: 5,
+			tickCount: 10,
+		};
+
+		it('should include title', () => {
+			const lines = buildGameScreen(mockState, 'test', 0, 5, '', 13);
+
+			expect(lines.some(line => line.includes('ÍSLENSKUR'))).toBe(true);
+		});
+
+		it('should include board', () => {
+			const lines = buildGameScreen(mockState, 'test', 0, 5, '', 13);
+
+			// Should have multiple lines (at least title + board + progress + stats)
+			expect(lines.length).toBeGreaterThan(5);
+		});
+
+		it('should include progress', () => {
+			const lines = buildGameScreen(mockState, 'test', 0, 5, '', 13);
+
+			const progressLine = lines.find(line => line.includes('tes'));
+			expect(progressLine).toBeDefined();
+		});
+
+		it('should include stats', () => {
+			const lines = buildGameScreen(mockState, 'test', 0, 5, '', 13);
+
+			const statsLine = lines.find(line => line.includes('2') && line.includes('1'));
+			expect(statsLine).toBeDefined();
+		});
+
+		it('should include feedback when provided', () => {
+			const feedback = 'Great job!';
+			const lines = buildGameScreen(mockState, 'test', 0, 5, feedback, 13);
+
+			expect(lines.some(line => line.includes(feedback))).toBe(true);
+		});
+
+		it('should not include feedback when empty', () => {
+			const lines = buildGameScreen(mockState, 'test', 0, 5, '', 13);
+
+			// Should still have lines, just without feedback line
+			expect(lines.length).toBeGreaterThan(0);
+		});
+	});
+
+	describe('buildWelcomeScreen', () => {
+		it('should include title', () => {
+			const lines = buildWelcomeScreen('test', 0, 5, 16, 13);
+
+			expect(lines.some(line => line.includes('ÍSLENSKUR'))).toBe(true);
+		});
+
+		it('should include level information', () => {
+			const lines = buildWelcomeScreen('test', 2, 10, 16, 13);
+
+			expect(lines.some(line => line.includes('3/10'))).toBe(true);
+		});
+
+		it('should include target word', () => {
+			const lines = buildWelcomeScreen('falleg', 0, 5, 16, 13);
+
+			expect(lines.some(line => line.includes('falleg'))).toBe(true);
+		});
+
+		it('should include instructions', () => {
+			const lines = buildWelcomeScreen('test', 0, 5, 16, 13);
+
+			expect(lines.some(line => line.includes('Stjórnun'))).toBe(true);
+		});
+
+		it('should show catch line indicator', () => {
+			const lines = buildWelcomeScreen('test', 0, 5, 16, 13);
+
+			expect(lines.some(line => line.includes('vallína'))).toBe(true);
+		});
+	});
+
+	describe('buildCompletionScreen', () => {
+		const mockStats: PerformanceStats = {
+			errorCount: 2,
+			missedLetters: 1,
+			isPerfect: false,
+		};
+
+		const mockFeedback: FeedbackMessage = {
+			message: 'Keep practicing!',
+			type: 'keep-practicing',
+		};
+
+		it('should show congratulations', () => {
+			const lines = buildCompletionScreen('test', 0, 5, mockStats, mockFeedback, true);
+
+			expect(lines.some(line => line.includes('HAMINGJU'))).toBe(true);
+		});
+
+		it('should show completed word', () => {
+			const lines = buildCompletionScreen('falleg', 0, 5, mockStats, mockFeedback, true);
+
+			expect(lines.some(line => line.includes('falleg'))).toBe(true);
+		});
+
+		it('should show level completion', () => {
+			const lines = buildCompletionScreen('test', 2, 10, mockStats, mockFeedback, true);
+
+			expect(lines.some(line => line.includes('3/10'))).toBe(true);
+		});
+
+		it('should show stats for non-perfect performance', () => {
+			const lines = buildCompletionScreen('test', 0, 5, mockStats, mockFeedback, true);
+
+			expect(lines.some(line => line.includes('2'))).toBe(true);
+			expect(lines.some(line => line.includes('1'))).toBe(true);
+		});
+
+		it('should show perfect message when perfect', () => {
+			const perfectStats: PerformanceStats = {
+				errorCount: 0,
+				missedLetters: 0,
+				isPerfect: true,
+			};
+			const perfectFeedback: FeedbackMessage = {
+				message: 'Perfect!',
+				type: 'perfect',
+			};
+
+			const lines = buildCompletionScreen('test', 0, 5, perfectStats, perfectFeedback, true);
+
+			expect(lines.some(line => line.includes('FULLKOMIÐ'))).toBe(true);
+		});
+
+		it('should ask to continue when has next level', () => {
+			const lines = buildCompletionScreen('test', 0, 5, mockStats, mockFeedback, true);
+
+			expect(lines.some(line => line.includes('y/n'))).toBe(true);
+		});
+
+		it('should show completion message when no next level', () => {
+			const lines = buildCompletionScreen('test', 4, 5, mockStats, mockFeedback, false);
+
+			expect(lines.some(line => line.includes('klárað öll stigin'))).toBe(true);
+		});
+	});
+
+	describe('buildAllCompleteScreen', () => {
+		it('should show congratulations', () => {
+			const lines = buildAllCompleteScreen(10);
+
+			expect(lines.some(line => line.includes('HAMINGJU'))).toBe(true);
+		});
+
+		it('should show total levels completed', () => {
+			const lines = buildAllCompleteScreen(10);
+
+			expect(lines.some(line => line.includes('10'))).toBe(true);
+		});
+	});
+
+	describe('buildNextLevelScreen', () => {
+		it('should show level information', () => {
+			const lines = buildNextLevelScreen('falleg', 2, 10);
+
+			expect(lines.some(line => line.includes('3/10'))).toBe(true);
+		});
+
+		it('should show target word', () => {
+			const lines = buildNextLevelScreen('falleg', 0, 5);
+
+			expect(lines.some(line => line.includes('falleg'))).toBe(true);
+		});
+
+		it('should show starting message', () => {
+			const lines = buildNextLevelScreen('test', 0, 5);
+
+			expect(lines.some(line => line.includes('byrjar'))).toBe(true);
+		});
+	});
+
+	describe('buildGoodbyeScreen', () => {
+		it('should show thank you message', () => {
+			const lines = buildGoodbyeScreen();
+
+			expect(lines.some(line => line.includes('Takk'))).toBe(true);
+		});
+
+		it('should show title', () => {
+			const lines = buildGoodbyeScreen();
+
+			expect(lines.some(line => line.includes('ÍSLENSKUR'))).toBe(true);
+		});
+	});
+
+	describe('renderWithFrame', () => {
+		it('should add top and bottom borders', () => {
+			const lines = ['test line 1', 'test line 2'];
+			const result = renderWithFrame(lines, 50, 100, 40);
+
+			// Should have more lines than input (borders + content)
+			expect(result.length).toBeGreaterThan(lines.length);
+		});
+
+		it('should include all content lines', () => {
+			const lines = ['line 1', 'line 2', 'line 3'];
+			const result = renderWithFrame(lines, 50, 100, 40);
+
+			// Each content line should be present
+			expect(result.some(line => line.includes('line 1'))).toBe(true);
+			expect(result.some(line => line.includes('line 2'))).toBe(true);
+			expect(result.some(line => line.includes('line 3'))).toBe(true);
+		});
+
+		it('should add vertical centering padding', () => {
+			const lines = ['test'];
+			const result = renderWithFrame(lines, 50, 100, 100);
+
+			// Should have empty lines for vertical centering
+			const emptyLines = result.filter(line => line === '');
+			expect(emptyLines.length).toBeGreaterThan(0);
+		});
+
+		it('should handle single line', () => {
+			const lines = ['single'];
+			const result = renderWithFrame(lines, 50, 100, 40);
+
+			expect(result.length).toBeGreaterThan(2); // At least borders + content
+			expect(result.some(line => line.includes('single'))).toBe(true);
+		});
+
+		it('should handle many lines', () => {
+			const lines = new Array(20).fill('line');
+			const result = renderWithFrame(lines, 50, 100, 40);
+
+			expect(result.length).toBeGreaterThan(20);
+		});
+	});
+});


### PR DESCRIPTION
- Install Vitest, @vitest/ui, and @vitest/coverage-v8
- Add test scripts to package.json (test, test:ui, test:coverage, test:run)
- Activate existing game-logic tests (rename .example.ts to .test.ts)
- Create 140 comprehensive tests across all core modules:
  * word-generation.test.ts (29 tests) - Tests FR-001/FR-002 logic
  * score-calculator.test.ts (19 tests) - All 4 feedback types
  * level-progression.test.ts (25 tests) - Shuffle and traversal logic
  * formatters.test.ts (58 tests) - All screen builders and formatting
  * game-logic.test.ts (9 tests) - Core game mechanics

All tests passing (140/140) with 100% coverage of pure functions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)