### PR TITLE
Fix demo to start with correct word length

### DIFF
--- a/demo.ts
+++ b/demo.ts
@@ -31,6 +31,9 @@ import {
 	CATCH_LINE_POSITION,
 	type GameState,
 } from './src/core/game-logic.js';
+import {
+	STARTING_WORD_LENGTH,
+} from './src/core/adaptive-scoring.js';
 
 // Demo configuration
 const FRAME_WIDTH = 50;
@@ -48,7 +51,7 @@ let bagOfChars: string[] = [];
 let currentTarget: string = '';
 let lastFeedback: string = '';
 let completedWords: number = 0;
-let currentWordLength: number = 7; // Start with medium difficulty word
+let currentWordLength: number = STARTING_WORD_LENGTH; // Start with same difficulty as main game
 
 /**
  * Select and initialize a new word


### PR DESCRIPTION
The demo was hardcoded to start with 7-letter words, which was inconsistent with the main game that starts with 3-letter words (STARTING_WORD_LENGTH).

Changes:
- Import STARTING_WORD_LENGTH from adaptive-scoring.ts
- Use STARTING_WORD_LENGTH instead of hardcoded value 7
- Update comment to reflect that demo now matches main game behavior

This ensures the demo accurately represents the actual game experience.